### PR TITLE
[RFC] something I tried that actually makes it slower

### DIFF
--- a/lib/neovim/client.rb
+++ b/lib/neovim/client.rb
@@ -97,6 +97,14 @@ module Neovim
       end
     end
 
+    def run_par(cbs)
+      @session.run_par(cbs)
+    end
+
+    def flush
+      @session.flush
+    end
+
     def shutdown
       @session.shutdown
     end

--- a/lib/neovim/connection.rb
+++ b/lib/neovim/connection.rb
@@ -40,13 +40,17 @@ module Neovim
 
     def write(object)
       log(:debug) { {object: object} }
-      @packer.write(object).flush
+      @packer.write(object)
     end
 
     def read
       @unpacker.read.tap do |object|
         log(:debug) { {object: object} }
       end
+    end
+
+    def flush
+      @packer.flush
     end
 
     def register_type(id)

--- a/lib/neovim/event_loop.rb
+++ b/lib/neovim/event_loop.rb
@@ -76,6 +76,7 @@ module Neovim
         break if @shutdown
 
         begin
+          flush
           yield read
         rescue EOFError => e
           log_exception(:debug, e, __method__)
@@ -98,6 +99,10 @@ module Neovim
           klass.new(index, session, api)
         end
       end
+    end
+
+    def flush
+      @connection.flush
     end
 
     private

--- a/lib/neovim/ruby_provider.rb
+++ b/lib/neovim/ruby_provider.rb
@@ -94,7 +94,10 @@ module Neovim
 
     def self.__wrap_client(client)
       Vim.__client = client
-      Vim.__refresh_globals(client)
+      client.run_par [
+        Vim.method(:refresh_curbuf),
+        Vim.method(:refresh_curwin),
+      ]
 
       __with_exception_handling(client) do
         __with_std_streams(client) do


### PR DESCRIPTION
Hi,

I took a look at your `buffer-optmz` branch.  I know it's not finished, but I tried to experiment with it and build on top of it.  Eventually, though, I realized that what I was trying to do was actually sort of an alternative to what you're doing, so I switched back to `master`.

Whereas your branch changes `Connection` to conditionally flush after writing depending on a flag, I change it to *never* flush after writing.  Instead, the event loop flushes pending writes when it's about to block on reading.

This approach works better with the other part of my change, which is to allow parallel calls from multiple fibers.  I add a helper method `run_par` which takes a list of callbacks and runs each of them on a new fiber, resuming the original fiber when all have finished.

As a first use, I change the code that re-requests the current buffer and window after every legacy Vim API call to do so in parallel:

```ruby
  @__client.run_par [
     lambda { resp = @__client.public_send(method, *args, &block) },
     method(:refresh_curbuf),
     method(:refresh_curwin),
  ]
```

I'm think (but am not sure) it's valid to send these requests 'in parallel' with the caller's actual request, which might change the current buffer/window.  The use of fibers rather than real threads guarantees that the requests will be sent out in order, and on neovim's end, I think it serializes request processing, so it won't handle the later requests until it's finished the first one?

Anyway, I confirmed this results in fewer write() calls / context switches.  Unfortunately, it also makes LustyJuggler much slower, rather than faster!  I think the creation of fibers and other objects for every request is adding GC pressure...  So for now this is kind of useless.  I'm submitting it anyway in case you had any thoughts on it – in particular, even if `run_par` is a bust, I think this approach to flushing is better.  I'll also try to see if I can get it running faster.