### PR TITLE
Remove handlers from @response_handlers after running them

### DIFF
--- a/lib/neovim/message.rb
+++ b/lib/neovim/message.rb
@@ -49,7 +49,7 @@ module Neovim
       end
 
       def received(handlers)
-        handlers[request_id].call(self)
+        handlers.delete(request_id).call(self)
       end
     end
 


### PR DESCRIPTION
Right now they just stay in there forever.