### PR TITLE
Update bundler and adjust CI caching

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,13 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: head
+      - name: Cache checksum
+        run: |
+          openssl md5 Gemfile neovim.gemspec > /tmp/checksum.txt
       - uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('{neovim.gemspec,Gemfile}') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('/tmp/checksum.txt') }}
           restore-keys: |
             ${{ runner.os }}-gems-
       - name: Bundle install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('{neovim.gemspec,Gemfile}') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
       - name: Bundle install
         run: |
           bundle config set path vendor/bundle
@@ -50,12 +44,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v1
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('{neovim.gemspec,Gemfile}') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
       - name: Bundle install
         run: |
           bundle config set path vendor/bundle
@@ -68,4 +56,3 @@ jobs:
         env:
           NVIM_EXECUTABLE: 'C:\tools\neovim\Neovim\bin\nvim'
         run: bundle exec rake spec
-

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,8 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
 
+Bundler.setup
+
 RuboCop::RakeTask.new(:linter)
 
 namespace :spec do
@@ -16,9 +18,7 @@ namespace :spec do
   namespace :acceptance do
     desc "Install acceptance spec dependencies"
     task :deps do
-      Bundler.with_clean_env do
-        sh "bundle exec vim-flavor update --vimfiles-path=spec/acceptance/runtime"
-      end
+      sh "vim-flavor update --vimfiles-path=spec/acceptance/runtime"
     end
   end
 end

--- a/neovim.gemspec
+++ b/neovim.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "msgpack", "~> 1.1"
   spec.add_dependency "multi_json", "~> 1.0"
 
-  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
- Update bundler to 2.0
- Don't cache dependencies in test runs to catch dependency regressions
- Cache deps for linter using checksum file