### PR TITLE
Remove references to $NVIM_LISTEN_ADDRESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ gem install neovim
 
 ## Usage
 
-You can control a running `nvim` process by connecting to `$NVIM_LISTEN_ADDRESS`. For example, to connect to `nvim` over a UNIX domain socket, start it up like this:
+Neovim supports the `--listen` option for specifying an address to serve its RPC API. To connect to Neovim over a Unix socket, start it up like this:
 
 ```shell
-$ NVIM_LISTEN_ADDRESS=/tmp/nvim.sock nvim
+$ nvim --listen /tmp/nvim.sock
 ```
 
 You can then connect to that socket path to get a `Neovim::Client`:

--- a/lib/neovim.rb
+++ b/lib/neovim.rb
@@ -10,11 +10,10 @@ require "neovim/version"
 # running +nvim+ instance programmatically or define a remote plugin to be
 # autoloaded by +nvim+.
 #
-# You can connect to a running +nvim+ instance by setting or inspecting the
-# +NVIM_LISTEN_ADDRESS+ environment variable and connecting via the appropriate
-# +attach_+ method. This is currently supported for both UNIX domain sockets
-# and TCP. You can also spawn and connect to an +nvim+ subprocess via
-# +Neovim.attach_child(argv)+.
+# You can connect to a running +nvim+ process using the appropriate +attach_+
+# method. This is currently supported for both UNIX domain sockets and TCP. You
+# can also spawn and connect to an +nvim+ subprocess using
+# +Neovim.attach_child+.
 #
 # You can define a remote plugin using the +Neovim.plugin+ DSL, which allows
 # you to register commands, functions, and autocmds. Plugins are autoloaded by


### PR DESCRIPTION
This will be removed in nvim 0.8+ in favor of `--listen` and `$NVIM`.

Fixes https://github.com/neovim/neovim-ruby/issues/82