### PR TITLE
Remove nvim version from generated docs

### DIFF
--- a/lib/neovim/buffer.rb
+++ b/lib/neovim/buffer.rb
@@ -3,8 +3,6 @@ require "neovim/line_range"
 
 module Neovim
   # Class representing an +nvim+ buffer.
-  #
-  # The methods documented here were generated using NVIM v0.11.1
   class Buffer < RemoteObject
     attr_reader :lines
 

--- a/lib/neovim/client.rb
+++ b/lib/neovim/client.rb
@@ -9,8 +9,6 @@ module Neovim
   # +RemoteObject+ subclasses (i.e. +Buffer+, +Window+, or +Tabpage+),
   # which similarly have dynamically generated interfaces.
   #
-  # The methods documented here were generated using NVIM v0.11.1
-  #
   # @see Buffer
   # @see Window
   # @see Tabpage

--- a/lib/neovim/tabpage.rb
+++ b/lib/neovim/tabpage.rb
@@ -2,8 +2,6 @@ require "neovim/remote_object"
 
 module Neovim
   # Class representing an +nvim+ tabpage.
-  #
-  # The methods documented here were generated using NVIM v0.11.1
   class Tabpage < RemoteObject
 # The following methods are dynamically generated.
 =begin

--- a/lib/neovim/window.rb
+++ b/lib/neovim/window.rb
@@ -2,8 +2,6 @@ require "neovim/remote_object"
 
 module Neovim
   # Class representing an +nvim+ window.
-  #
-  # The methods documented here were generated using NVIM v0.11.1
   class Window < RemoteObject
     # Get the buffer displayed in the window
     #

--- a/script/generate_docs.rb
+++ b/script/generate_docs.rb
@@ -10,7 +10,6 @@ buffer_docs = []
 window_docs = []
 tabpage_docs = []
 nvim_exe = ENV.fetch("NVIM_EXECUTABLE", "nvim")
-nvim_vrs = %x(#{nvim_exe} --version).split("\n").first
 
 event_loop = Neovim::EventLoop.child([nvim_exe, "-u", "NONE", "-n"])
 session = Neovim::Session.new(event_loop)
@@ -83,10 +82,6 @@ lib_dir = Pathname.new(File.expand_path("../lib/neovim", __dir__))
   doc_str = ["=begin", *docs, "=end"].join("\n")
 
   contents.sub!(/=begin.+=end/m, doc_str)
-  contents.sub!(
-    /# The methods documented here were generated using .+$/,
-    "# The methods documented here were generated using #{nvim_vrs}"
-  )
 
   File.write(path, contents)
 end


### PR DESCRIPTION
I don't think this is particularly helpful to document and it also requires me to review documentation changes that only update the version.